### PR TITLE
Update Fyber FairBid 2 version from 2.1.0 to 2.2.0

### DIFF
--- a/Fyber FairBid/AdsScreenViewController.swift
+++ b/Fyber FairBid/AdsScreenViewController.swift
@@ -116,7 +116,7 @@ class AdsScreenViewController: UIViewController, UITableViewDataSource, FYBInter
         } else {
             let bannerOptions = FYBBannerOptions()
 
-            bannerOptions.placementId = bannerPlacementID as NSString
+            bannerOptions.placementId = bannerPlacementID
             FYBBanner.show(in: bannerView, position: .top, options: bannerOptions)
         }
         fetchingInProgress()

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 platform :ios, '8.0'
 
 target 'Fyber FairBid' do
-	pod 'FairBidSDK', '2.1.1' 
+	pod 'FairBidSDK', '2.2.0' 
 end
 
 post_install do |installer|

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # fairbid-sample-app-ios
+
 The sample app for our customers.
+
+## Build instructions
+
+Run the following commands in the terminal,
+
+```bash
+
+cd fairbid-sample-app-ios
+bundle install
+pod install
+
+```


### PR DESCRIPTION
- fix README.md
  - Added section build instructions
- fix AdsScreenViewController
  - removed force type casting of NSString to bannerPlacementID. Swift type inference assigns the datatype to the bannerPlacementID.