### PR TITLE
CMOB-830 Update FariBidSDK from 2.4.0 to 2.5.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,9 @@
 use_frameworks!
 
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 target 'Fyber FairBid' do
-  pod 'FairBidSDK', '2.4.0'
+  pod 'FairBidSDK', '2.5.0'
 end
 
 post_install do |installer|


### PR DESCRIPTION
- Update platform iOS version from 8.0 to 9.0. As FairBidSDK supports from iOS 9 +.